### PR TITLE
Fix ros::Time -> rcl::Time constuctor conversion bug

### DIFF
--- a/global_fusion/src/globalOpt.cpp
+++ b/global_fusion/src/globalOpt.cpp
@@ -58,7 +58,7 @@ void GlobalOptimization::inputOdom(double t, Eigen::Vector3d OdomP, Eigen::Quate
     lastQ = globalQ;
 
     geometry_msgs::msg::PoseStamped pose_stamped;
-    pose_stamped.header.stamp = rclcpp::Time(t);
+    pose_stamped.header.stamp = rclcpp::Time(static_cast<int64_t>(t*1e9));
     pose_stamped.header.frame_id = "world";
     pose_stamped.pose.position.x = lastP.x();
     pose_stamped.pose.position.y = lastP.y();
@@ -258,7 +258,7 @@ void GlobalOptimization::updateGlobalPath()
     for (iter = globalPoseMap.begin(); iter != globalPoseMap.end(); iter++)
     {
         geometry_msgs::msg::PoseStamped pose_stamped;
-        pose_stamped.header.stamp = rclcpp::Time(iter->first);
+        pose_stamped.header.stamp = rclcpp::Time(static_cast<int64_t>(iter->first*1e9));
         pose_stamped.header.frame_id = "world";
         pose_stamped.pose.position.x = iter->second[0];
         pose_stamped.pose.position.y = iter->second[1];

--- a/global_fusion/src/globalOptNode.cpp
+++ b/global_fusion/src/globalOptNode.cpp
@@ -38,7 +38,7 @@ void publish_car_model(double t, Eigen::Vector3d t_w_car, Eigen::Quaterniond q_w
 {
     visualization_msgs::msg::MarkerArray markerArray_msg;
     visualization_msgs::msg::Marker car_mesh;
-    car_mesh.header.stamp = rclcpp::Time(t);
+    car_mesh.header.stamp = rclcpp::Time(static_cast<int64_t>(t*1e9));
     car_mesh.header.frame_id = "world";
     car_mesh.type = visualization_msgs::msg::Marker::MESH_RESOURCE;
     car_mesh.action = visualization_msgs::msg::Marker::ADD;

--- a/loop_fusion/src/keyframe.cpp
+++ b/loop_fusion/src/keyframe.cpp
@@ -474,7 +474,7 @@ bool KeyFrame::findConnection(KeyFrame* old_kf)
 	            	cv::resize(loop_match_img, thumbimage, cv::Size(loop_match_img.cols / 2, loop_match_img.rows / 2));
 	    	    	// sensor_msgs::msg::ImagePtr
 					sensor_msgs::msg::Image::SharedPtr msg = cv_bridge::CvImage(std_msgs::msg::Header(), "bgr8", thumbimage).toImageMsg();
-	                msg->header.stamp = rclcpp::Time(time_stamp);
+	                msg->header.stamp = rclcpp::Time(static_cast<int64_t>(time_stamp*1e9));
 	    	    	pub_match_img->publish(*msg);
 	            }
 	        }

--- a/loop_fusion/src/pose_graph.cpp
+++ b/loop_fusion/src/pose_graph.cpp
@@ -167,7 +167,7 @@ void PoseGraph::addKeyFrame(KeyFrame* cur_kf, bool flag_detect_loop)
     cur_kf->updatePose(P, R);
     Quaterniond Q{R};
     geometry_msgs::msg::PoseStamped pose_stamped;
-    pose_stamped.header.stamp = rclcpp::Time(cur_kf->time_stamp);
+    pose_stamped.header.stamp = rclcpp::Time(static_cast<int64_t>(cur_kf->time_stamp*1e9));
     pose_stamped.header.frame_id = "world";
     pose_stamped.pose.position.x = P.x() + VISUALIZATION_SHIFT_X;
     pose_stamped.pose.position.y = P.y() + VISUALIZATION_SHIFT_Y;
@@ -271,7 +271,7 @@ void PoseGraph::loadKeyFrame(KeyFrame* cur_kf, bool flag_detect_loop)
     cur_kf->getPose(P, R);
     Quaterniond Q{R};
     geometry_msgs::msg::PoseStamped pose_stamped;
-    pose_stamped.header.stamp = rclcpp::Time(cur_kf->time_stamp);
+    pose_stamped.header.stamp = rclcpp::Time(static_cast<int64_t>(cur_kf->time_stamp*1e9));
     pose_stamped.header.frame_id = "world";
     pose_stamped.pose.position.x = P.x() + VISUALIZATION_SHIFT_X;
     pose_stamped.pose.position.y = P.y() + VISUALIZATION_SHIFT_Y;
@@ -806,7 +806,7 @@ void PoseGraph::updatePath()
 //        printf("path p: %f, %f, %f\n",  P.x(),  P.z(),  P.y() );
 
         geometry_msgs::msg::PoseStamped pose_stamped;
-        pose_stamped.header.stamp = rclcpp::Time((*it)->time_stamp);
+        pose_stamped.header.stamp = rclcpp::Time(static_cast<int64_t>((*it)->time_stamp*1e9));
         pose_stamped.header.frame_id = "world";
         pose_stamped.pose.position.x = P.x() + VISUALIZATION_SHIFT_X;
         pose_stamped.pose.position.y = P.y() + VISUALIZATION_SHIFT_Y;

--- a/vins_estimator/src/KITTIGPSTest.cpp
+++ b/vins_estimator/src/KITTIGPSTest.cpp
@@ -159,7 +159,7 @@ int main(int argc, char** argv)
 
 			sensor_msgs::msg::NavSatFix gps_position;
 			gps_position.header.frame_id = "NED";
-			gps_position.header.stamp = rclcpp::Time(imgTime);
+			gps_position.header.stamp = rclcpp::Time(static_cast<double>(imgTime*1e9));
 			gps_position.status.status = navstat;
 			gps_position.status.service = numsats;
 			gps_position.latitude  = lat;

--- a/vins_estimator/src/KITTIOdomTest.cpp
+++ b/vins_estimator/src/KITTIOdomTest.cpp
@@ -95,13 +95,13 @@ int main(int argc, char** argv)
 			imLeft = cv::imread(leftImagePath, cv::IMREAD_GRAYSCALE );
 			// sensor_msgs::msg::ImagePtr 
 			auto imLeftMsg = cv_bridge::CvImage(std_msgs::msg::Header(), "mono8", imLeft).toImageMsg();
-			imLeftMsg->header.stamp = rclcpp::Time(imageTimeList[i]);
+			imLeftMsg->header.stamp = rclcpp::Time(static_cast<int64_t>(imageTimeList[i]*1e9));
 			pubLeftImage->publish(*imLeftMsg);
 
 			imRight = cv::imread(rightImagePath, cv::IMREAD_GRAYSCALE );
 			// sensor_msgs::msg::ImagePtr 
 			auto imRightMsg = cv_bridge::CvImage(std_msgs::msg::Header(), "mono8", imRight).toImageMsg();
-			imRightMsg->header.stamp = rclcpp::Time(imageTimeList[i]);
+			imRightMsg->header.stamp = rclcpp::Time(static_cast<int64_t>(imageTimeList[i]*1e9));
 			pubRightImage->publish(*imRightMsg);
 
 

--- a/vins_estimator/src/estimator/estimator.cpp
+++ b/vins_estimator/src/estimator/estimator.cpp
@@ -349,7 +349,7 @@ void Estimator::processMeasurements()
 
             std_msgs::msg::Header header;
             header.frame_id = "world";
-            header.stamp = rclcpp::Time(feature.first);
+            header.stamp = rclcpp::Time(static_cast<int64_t>(feature.first*1e9));
 
             pubOdometry(*this, header);
             // cout << "5-1" << endl;

--- a/vins_estimator/src/utility/visualization.cpp
+++ b/vins_estimator/src/utility/visualization.cpp
@@ -53,7 +53,7 @@ void registerPub(rclcpp::Node::SharedPtr n)
 void pubLatestOdometry(const Eigen::Vector3d &P, const Eigen::Quaterniond &Q, const Eigen::Vector3d &V, double t)
 {
     nav_msgs::msg::Odometry odometry;
-    odometry.header.stamp = rclcpp::Time(t);
+    odometry.header.stamp = rclcpp::Time(static_cast<int64_t>(t*1e9));
     odometry.header.frame_id = "world";
     odometry.pose.pose.position.x = P.x();
     odometry.pose.pose.position.y = P.y();
@@ -72,7 +72,7 @@ void pubTrackImage(const cv::Mat &imgTrack, const double t)
 {
     std_msgs::msg::Header header;
     header.frame_id = "world";
-    header.stamp = rclcpp::Time(t);
+    header.stamp = rclcpp::Time(static_cast<int64_t>(t*1e9));
     // sensor_msgs::msg::ImagePtr 
     sensor_msgs::msg::Image::SharedPtr imgTrackMsg = cv_bridge::CvImage(header, "bgr8", imgTrack).toImageMsg();
     pub_image_track->publish(*imgTrackMsg);
@@ -472,7 +472,7 @@ void pubKeyframe(const Estimator &estimator)
         Quaterniond R = Quaterniond(estimator.Rs[i]);
 
         nav_msgs::msg::Odometry odometry;
-        odometry.header.stamp = rclcpp::Time(estimator.Headers[WINDOW_SIZE - 2]);
+        odometry.header.stamp = rclcpp::Time(static_cast<int64_t>(estimator.Headers[WINDOW_SIZE - 2])*1e9);
         odometry.header.frame_id = "world";
         odometry.pose.pose.position.x = P.x();
         odometry.pose.pose.position.y = P.y();
@@ -487,7 +487,7 @@ void pubKeyframe(const Estimator &estimator)
 
 
         sensor_msgs::msg::PointCloud point_cloud;
-        point_cloud.header.stamp = rclcpp::Time(estimator.Headers[WINDOW_SIZE - 2]);
+        point_cloud.header.stamp = rclcpp::Time(static_cast<int64_t>(estimator.Headers[WINDOW_SIZE - 2])*1e9);
         point_cloud.header.frame_id = "world";
         for (auto &it_per_id : estimator.f_manager.feature)
         {


### PR DESCRIPTION
I was experimenting with your ros2/cuda fork.
For some reason, ros2 does not have a `rclcpp::Time(double)` constructor.
What happens instead (probably depends on compiler and system):
1. The `double` get implicitly converted to either `int32_t` or `int64_t`.
2. The `rclcpp::Time` constructor interprets `int32_t` as seconds and `int64_t` as nanoseconds.

Therefore, the behavior differs depending on the implicit conversion, and even for the right `int32_t` cast, the nanoseconds are lost.
I changed to explicit `static_cast` conversion to the nanosecond value.
